### PR TITLE
doc: known issues: add peripheral_uart known issue

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1518,6 +1518,13 @@ Bluetooth samples
 
 .. rst-class:: v2-4-0
 
+NCSDK-21709: :ref:`peripheral_uart` sample does not work on nRF52810 and nRF52811 devices.
+  Initialization of the Bluetooth stack fails.
+
+  **Workaround:** Enable the :kconfig:option:`CONFIG_BT_SETTINGS` option in the project configuration file (:file:`prj_minimal.conf`).
+
+.. rst-class:: v2-4-0
+
 NCSDK-21590: :ref:`bluetooth_mesh_sensor_client` sample does not compile for nRF52832
   Adding mesh shell support for the :ref:`bluetooth_mesh_sensor_client` sample increases the need for RAM.
   The :ref:`bluetooth_mesh_sensor_client` sample cannot compile because of RAM shortage.


### PR DESCRIPTION
`peripheral_uart` sample does not work on nRF52810 and nRF52811 devices.